### PR TITLE
updateNodeVisibility on hide and reveal

### DIFF
--- a/eventtypes/event/hideuntildate/hideuntildatetype.php
+++ b/eventtypes/event/hideuntildate/hideuntildatetype.php
@@ -67,6 +67,7 @@ class hideUntilDateType extends eZWorkflowEventType
                             if( !$node->attribute( 'is_hidden' ) )
                             {
                                 eZContentObjectTreeNode::hideSubTree( $node );
+                                eZSearch::updateNodeVisibility( $node->attribute( 'node_id' ), 'hide' );
                             }
                         }
                         return eZWorkflowType::STATUS_DEFERRED_TO_CRON_REPEAT;
@@ -83,6 +84,7 @@ class hideUntilDateType extends eZWorkflowEventType
                         foreach( $nodes as $node )
                         {
                             eZContentObjectTreeNode::unhideSubTree( $node );
+                            eZSearch::updateNodeVisibility( $node->attribute( 'node_id' ), 'show' );
                             eZContentCacheManager::clearContentCache( $parameters['object_id'] );
                             eZContentCacheManager::clearObjectViewCache( $parameters['object_id'] );
                         }


### PR DESCRIPTION
The hide and reveal operations are not currently updating the search index. This means that future-dated objects (which are published as hidden) do not get the hidden and invisible flags updated when using Solr.